### PR TITLE
feat: shorten timeout for subscribing dummy lidar

### DIFF
--- a/awsim_sensor_kit_launch/launch/pointcloud_preprocessor.launch.py
+++ b/awsim_sensor_kit_launch/launch/pointcloud_preprocessor.launch.py
@@ -41,6 +41,7 @@ def launch_setup(context, *args, **kwargs):
                     "/sensing/lidar/right/outlier_filtered/pointcloud",
                 ],
                 "output_frame": LaunchConfiguration("base_frame"),
+                "timeout_sec": 0.01,
             }
         ],
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],


### PR DESCRIPTION
Signed-off-by: Shumpei Wakabayashi <shumpei.wakabayashi@tier4.jp>

## Description

<!-- Write a brief description of this PR. -->
Current Hz of `/sensing/lidar/concatenated/pointcloud ` is about 5Hz, which is slower than we expected and has a negative impact on subsequent processing.
Current AWSIM impliments only the top lidar. 
On the other hands,  `awsim_sesnsor_kit_launch` includes a dummy left and right lidar as input to simulate the pointcloud concatenate function.
Thus this PR shortens the timeout for subscribing the dummy lidar.
It can improve the Hz of `/sensing/lidar/concatenated/pointcloud ` up to 10Hz.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
