### PR TITLE
fix(xacro): replace load_yaml with xacro.load_yaml

### DIFF
--- a/awsim_sensor_kit_description/urdf/sensor_kit.xacro
+++ b/awsim_sensor_kit_description/urdf/sensor_kit.xacro
@@ -21,7 +21,7 @@
     </link>
 
     <!-- sensor -->
-    <xacro:property name="calibration" value="${load_yaml('$(arg config_dir)/sensor_kit_calibration.yaml')}"/>
+    <xacro:property name="calibration" value="${xacro.load_yaml('$(arg config_dir)/sensor_kit_calibration.yaml')}"/>
 
     <!-- lidar -->
     <xacro:VLS-128 parent="sensor_kit_base_link" name="velodyne_top" topic="/points_raw" hz="10" samples="220" gpu="$(arg gpu)">

--- a/awsim_sensor_kit_description/urdf/sensors.xacro
+++ b/awsim_sensor_kit_description/urdf/sensors.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot name="vehicle" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:arg name="config_dir" default="$(find awsim_sensor_kit_description)/config"/>
-  <xacro:property name="calibration" value="${load_yaml('$(arg config_dir)/sensors_calibration.yaml')}"/>
+  <xacro:property name="calibration" value="${xacro.load_yaml('$(arg config_dir)/sensors_calibration.yaml')}"/>
 
   <!-- sensor kit -->
   <xacro:include filename="sensor_kit.xacro"/>


### PR DESCRIPTION
## Description

From humble, `load_yaml` should be replaced with `xacro.load_yaml` to suppress warnings.

## Related links

- https://github.com/autowarefoundation/autoware/issues/3322
- https://github.com/autowarefoundation/autoware.universe/issues/2977
- https://github.com/autowarefoundation/autoware_individual_params/pull/42

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/