### PR TITLE
feat(imu_corrector): add gyro_bias_estimator

### DIFF
--- a/awsim_sensor_kit_launch/launch/imu.launch.xml
+++ b/awsim_sensor_kit_launch/launch/imu.launch.xml
@@ -7,5 +7,12 @@
       <!-- We are using default node values -->
       <!-- <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/awsim_sensor_kit/imu_corrector.param.yaml"/> -->
     </include>
+
+    <include file="$(find-pkg-share imu_corrector)/launch/gyro_bias_estimator.launch.xml">
+      <arg name="input_imu_raw" value="tamagawa/imu_raw"/>
+      <arg name="input_pose" value="/localization/pose_estimator/pose_with_covariance"/>
+      <!-- We are using default node values -->
+      <!-- <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/awsim_sensor_kit/imu_corrector.param.yaml"/> -->
+    </include>
   </group>
 </launch>


### PR DESCRIPTION
## Description

Modified to launch `gyro_bias_estimator`. Additionally, since the `gyro_bias_estimator` is modified to use pose in a following pull request, it has been adapted to use pose here as well.

See https://github.com/autowarefoundation/autoware.universe/pull/5259

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
