### PR TITLE
chore(package_xml): added autoware_ prefix to gnss_poser

### DIFF
--- a/awsim_sensor_kit_launch/package.xml
+++ b/awsim_sensor_kit_launch/package.xml
@@ -9,9 +9,9 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <exec_depend>autoware_gnss_poser</exec_depend>
   <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
   <exec_depend>common_sensor_launch</exec_depend>
-  <exec_depend>gnss_poser</exec_depend>
   <exec_depend>tamagawa_imu_driver</exec_depend>
   <exec_depend>topic_tools</exec_depend>
   <exec_depend>ublox_gps</exec_depend>


### PR DESCRIPTION
## Description

[Following the movement of adding `autoware_` prefix to package names](https://github.com/autowarefoundation/autoware/issues/4569), this PR adds autoware prefix to gnss_poser.

## Related links

**Since this PR strongly relates to sensor launching systems, this PR must be merged together with the following PRs.**
- https://github.com/autowarefoundation/autoware.universe/pull/8323
- https://github.com/autowarefoundation/sample_sensor_kit_launch/pull/100
- https://github.com/tier4/aip_launcher/pull/283
- https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch/pull/4

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
